### PR TITLE
Add liboqs

### DIFF
--- a/dev-libs/liboqs/liboqs-0.9.2.ebuild
+++ b/dev-libs/liboqs/liboqs-0.9.2.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson cmake
+
+DESCRIPTION="C library for prototyping and experimenting with quantum-resistant cryptography"
+HOMEPAGE="https://openquantumsafe.org/"
+
+if [[ ${PV} == *_p* ]] ; then
+	MY_P=${PN}-$(ver_cut 1-3)-stable-$(ver_cut 5-)
+
+	# We use _pN to represent 'stable releases'
+	# These are backports from upstream to the last release branch
+	# See https://download.libsodium.org/libsodium/releases/README.html
+	SRC_URI="
+		https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${MY_P}.tar.gz -> ${P}.tar.gz
+		verify-sig? ( https://dev.gentoo.org/~sam/distfiles/dev-libs/libsodium/${MY_P}.tar.gz.minisig -> ${P}.tar.gz.minisig )
+	"
+else
+	SRC_URI="
+		https://download.libsodium.org/${PN}/releases/${P}.tar.gz
+		verify-sig? ( https://download.libsodium.org/${PN}/releases/${P}.tar.gz.minisig )
+	"
+fi
+
+S="${WORKDIR}"/${PN}-stable
+
+LICENSE="ISC"
+SLOT="0/26"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~arm64-macos ~x64-macos"
+IUSE="+asm static-libs +urandom"
+
+CPU_USE=( cpu_flags_x86_{aes,sse4_1} )
+IUSE+=" ${CPU_USE[@]}"
+
+BDEPEND=" verify-sig? ( sec-keys/minisig-keys-libsodium )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.10-cpuflags.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(use_enable asm)
+		$(use_enable cpu_flags_x86_aes aesni)
+		$(use_enable cpu_flags_x86_sse4_1 sse4_1)
+		$(use_enable static-libs static)
+		$(use_enable !urandom blocking-random)
+	)
+
+	# --disable-pie is needed on x86, see bug #512734
+	# TODO: Check if still needed?
+	if [[ ${ABI} == x86 ]] ; then
+		myeconfargs+=( --disable-pie )
+	fi
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	default
+	find "${ED}" -type f -name "*.la" -delete || die
+}


### PR DESCRIPTION
Prototype quantum encryption library used by IVPN.
[https://github.com/open-quantum-safe/liboqs](https://github.com/open-quantum-safe/liboqs)